### PR TITLE
Simplify .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,19 +5,14 @@ charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = tab
-indent_size = 4
-
-[*.{js,jsx,scss,css,json,yaml,yml,feature,xml}]
 indent_style = space
 indent_size = 2
+
+[*.{html,php}]
+indent_size = 4
+indent_style = tab
 
 # Composer File
 [composer.{json,lock}]
 indent_style = space
 indent_size = 4
-
-# Dotfiles
-[.*]
-indent_style = space
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,3 @@ indent_size = 2
 [*.{html,php}]
 indent_size = 4
 indent_style = tab
-
-# Composer File
-[composer.{json,lock}]
-indent_style = space
-indent_size = 4


### PR DESCRIPTION
We can simplify this quite a bit by setting 2 spaces as the default and overriding where necessary. I left the Composer-related declarations in place, because there appears to be a specific reason for those settings(?).